### PR TITLE
Replaced include statements with "" instead of <> for local files.

### DIFF
--- a/InitialConditions/initialcondition.cpp
+++ b/InitialConditions/initialcondition.cpp
@@ -1,4 +1,4 @@
-#include <InitialConditions/initialcondition.h>
+#include "initialcondition.h"
 
 std::string InitialCondition::getName() {
     return "Unkown";

--- a/InitialConditions/initialcondition.h
+++ b/InitialConditions/initialcondition.h
@@ -1,12 +1,12 @@
 #pragma once
 #include <vector>
-#include <particle.h>
 #include <string>
+#include "../particle.h"
 
 class InitialCondition {
 public:
     InitialCondition() {}
-    virtual void setupParticles(class System* system) = 0;
+    virtual void setupParticles(class System& system) = 0;
     virtual std::string getName();
 };
 

--- a/InitialConditions/threebody.cpp
+++ b/InitialConditions/threebody.cpp
@@ -1,10 +1,10 @@
-#include <InitialConditions/threebody.h>
-#include <vec3.h>
-#include <system.h>
+#include "threebody.h"
+#include "../vec3.h"
+#include "../system.h"
 #include <cmath>
 
 
-void ThreeBody::setupParticles(System* system) {
+void ThreeBody::setupParticles(System &system) {
     /*
      * This is where you should implement the initialization of a three-body
      * system.

--- a/InitialConditions/threebody.h
+++ b/InitialConditions/threebody.h
@@ -1,11 +1,10 @@
 #pragma once
-#include <InitialConditions/initialcondition.h>
+#include "../InitialConditions/initialcondition.h"
 #include <string>
-
 
 class ThreeBody : public InitialCondition {
 public:
     ThreeBody() {}
-    void setupParticles(class System* system);
+    void setupParticles(class System& system);
     std::string getName();
 };

--- a/InitialConditions/twobody.cpp
+++ b/InitialConditions/twobody.cpp
@@ -1,10 +1,10 @@
-#include <InitialConditions/twobody.h>
-#include <vec3.h>
-#include <system.h>
+#include "twobody.h"
+#include "../vec3.h"
+#include "../system.h"
 #include <cmath>
 
 
-void TwoBody::setupParticles(System* system) {
+void TwoBody::setupParticles(System &system) {
     /*
      * Here, two bodies are created at a distance r=1.0 apart from eachother.
      * A heavy body is placed in the origin, while a lighter body is placed
@@ -26,8 +26,8 @@ void TwoBody::setupParticles(System* system) {
 
     Particle* largeBody = new Particle(vec3(0,0,0), vec3(0,0,0), 1.0);
     Particle* smallBody = new Particle(vec3(1,0,0), vec3(0,1,0), 0.1);
-    system->addParticle(largeBody);
-    system->addParticle(smallBody);
+    system.addParticle(largeBody);
+    system.addParticle(smallBody);
 }
 
 std::string TwoBody::getName() {

--- a/InitialConditions/twobody.h
+++ b/InitialConditions/twobody.h
@@ -1,6 +1,6 @@
 #pragma once
-#include <InitialConditions/initialcondition.h>
-#include <particle.h>
+#include "../InitialConditions/initialcondition.h"
+#include "../particle.h"
 #include <vector>
 #include <string>
 
@@ -8,7 +8,7 @@
 class TwoBody : public InitialCondition {
 public:
     TwoBody() {}
-    void setupParticles(class System* system);
+    void setupParticles(class System& system);
     std::string getName();
 };
 

--- a/Integrators/eulercromer.cpp
+++ b/Integrators/eulercromer.cpp
@@ -1,6 +1,5 @@
-#include <Integrators/eulercromer.h>
-#include <Integrators/integrator.h>
-#include <system.h>
+#include "eulercromer.h"
+#include "../system.h"
 
 EulerCromer::EulerCromer(System* system)
     : Integrator(system) {

--- a/Integrators/eulercromer.h
+++ b/Integrators/eulercromer.h
@@ -1,7 +1,7 @@
 #pragma once
-#include <Integrators/integrator.h>
+#include "integrator.h"
+#include "../particle.h"
 #include <vector>
-#include <particle.h>
 
 class EulerCromer : public Integrator {
 public:

--- a/Integrators/integrator.cpp
+++ b/Integrators/integrator.cpp
@@ -1,5 +1,5 @@
-#include <Integrators/integrator.h>
-#include <system.h>
+#include "integrator.h"
+#include "../system.h"
 
 Integrator::Integrator(System* system) {
     m_system = system;

--- a/Integrators/integrator.h
+++ b/Integrators/integrator.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <vector>
 #include <string>
-#include <particle.h>
+#include "../particle.h"
 
 class Integrator {
 protected:

--- a/Integrators/velocityverlet.cpp
+++ b/Integrators/velocityverlet.cpp
@@ -1,6 +1,5 @@
-#include <Integrators/velocityverlet.h>
-#include <Integrators/integrator.h>
-#include <system.h>
+#include "velocityverlet.h"
+#include "../system.h"
 
 VelocityVerlet::VelocityVerlet(System* system)
     : Integrator(system) {

--- a/Integrators/velocityverlet.h
+++ b/Integrators/velocityverlet.h
@@ -1,7 +1,7 @@
 #pragma once
-#include <Integrators/integrator.h>
+#include "integrator.h"
+#include "../particle.h"
 #include <string>
-#include <particle.h>
 
 class VelocityVerlet : public Integrator {
 private:

--- a/Potentials/newtoniangravity.cpp
+++ b/Potentials/newtoniangravity.cpp
@@ -1,11 +1,11 @@
-#include <Potentials/newtoniangravity.h>
+#include "newtoniangravity.h"
 #include <iostream>
 
-NewtonianGravity::NewtonianGravity(double G) {
-    m_G = G;
+NewtonianGravity::NewtonianGravity(double G) : m_G(G) {
+
 }
 
-void NewtonianGravity::computeForces(Particle* a, Particle* b) {
+void NewtonianGravity::computeForces(Particle& a, Particle& b) {
     /*
      * This is where the ordinary Newtoninan gravity forces and potential
      * energies should be calculated. This method is called by the System
@@ -14,8 +14,8 @@ void NewtonianGravity::computeForces(Particle* a, Particle* b) {
      * Note that you may access the mass and the position of the particles a
      * and b by
      *
-     *      a->getMass();       b->getMass();
-     *      a->getPosition();   b->getPosition();
+     *      a.getMass();       b.getMass();
+     *      a.getPosition();   b.getPosition();
      *
      * In order to apply the forces to each particle, it is easiest to use the
      * Particle::addForce method.
@@ -30,8 +30,8 @@ void NewtonianGravity::computeForces(Particle* a, Particle* b) {
 
     // ...
     //m_potentialEnergy += V;
-    //a->addForce(dFx, dFy, dFz);
-    //b->addForce(...);
+    //a.addForce(dFx, dFy, dFz);
+    //b.addForce(...);
 }
 
 std::string NewtonianGravity::getName() {

--- a/Potentials/newtoniangravity.h
+++ b/Potentials/newtoniangravity.h
@@ -1,14 +1,14 @@
 #pragma once
-#include <particle.h>
+#include "particle.h"
+#include "potential.h"
 #include <string>
-#include <Potentials/potential.h>
 
 class NewtonianGravity : public Potential {
 private:
-    double m_G = 0;
+    double m_G;
 
 public:
     NewtonianGravity(double G);
-    void computeForces(Particle* a, Particle* b);
+    void computeForces(Particle& a, Particle& b);
     std::string getName();
 };

--- a/Potentials/nopotential.cpp
+++ b/Potentials/nopotential.cpp
@@ -1,4 +1,4 @@
-#include <Potentials/nopotential.h>
+#include "nopotential.h"
 
 
 std::string NoPotential::getName() {

--- a/Potentials/nopotential.cpp
+++ b/Potentials/nopotential.cpp
@@ -6,7 +6,7 @@ std::string NoPotential::getName() {
 }
 
 
-void NoPotential::computeForces(Particle*, Particle*) {
+void NoPotential::computeForces(Particle&, Particle&) {
     /*
      * No potential means just no forces acting between the particles, so
      * we dont have to do anything here. This potential can be used to test

--- a/Potentials/nopotential.h
+++ b/Potentials/nopotential.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <Potentials/potential.h>
+#include "potential.h"
 #include <string>
 
 class NoPotential : public Potential {

--- a/Potentials/nopotential.h
+++ b/Potentials/nopotential.h
@@ -6,5 +6,5 @@ class NoPotential : public Potential {
 public:
     NoPotential() {}
     std::string getName();
-    void computeForces(Particle*, Particle*);
+    void computeForces(Particle&, Particle&);
 };

--- a/Potentials/potential.cpp
+++ b/Potentials/potential.cpp
@@ -1,4 +1,4 @@
-#include <Potentials/potential.h>
+#include "potential.h"
 
 std::string Potential::getName() {
     return "Unknown";

--- a/Potentials/potential.h
+++ b/Potentials/potential.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <particle.h>
+#include "../particle.h"
 #include <string>
 
 class Potential {
@@ -8,7 +8,7 @@ protected:
 
 public:
     Potential() {}
-    virtual void computeForces(Particle* a, Particle* b) = 0;
+    virtual void computeForces(Particle& a, Particle& b) = 0;
     virtual std::string getName();
     void   resetPotentialEnergy() { m_potentialEnergy = 0; }
     double getPotentialEnergy()   { return m_potentialEnergy; }

--- a/examples.cpp
+++ b/examples.cpp
@@ -1,14 +1,14 @@
-#include <examples.h>
+#include "examples.h"
+#include "system.h"
+#include "particle.h"
+#include "Integrators/eulercromer.h"
+#include "Integrators/velocityverlet.h"
+#include "Potentials/newtoniangravity.h"
+#include "Potentials/nopotential.h"
+#include "InitialConditions/twobody.h"
+#include "InitialConditions/threebody.h"
 #include <iostream>
 #include <cmath>
-#include <system.h>
-#include <particle.h>
-#include <Integrators/eulercromer.h>
-#include <Integrators/velocityverlet.h>
-#include <Potentials/newtoniangravity.h>
-#include <Potentials/nopotential.h>
-#include <InitialConditions/twobody.h>
-#include <InitialConditions/threebody.h>
 
 
 void Examples::twoBodyProblem() {

--- a/main.cpp
+++ b/main.cpp
@@ -1,5 +1,5 @@
 #include <iostream>
-#include <examples.h>
+#include "examples.h"
 
 int main(int, char**) {
     Examples::twoBodyProblem();

--- a/particle.cpp
+++ b/particle.cpp
@@ -1,5 +1,5 @@
-#include <particle.h>
-#include <vec3.h>
+#include "particle.h"
+#include "vec3.h"
 
 Particle::Particle()
         : Particle(vec3(), vec3(), 0) {

--- a/particle.h
+++ b/particle.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <vec3.h>
+#include "vec3.h"
 
 class Particle {
 private:

--- a/system.cpp
+++ b/system.cpp
@@ -1,10 +1,10 @@
-#include <system.h>
-#include <iostream>
-#include <Integrators/integrator.h>
-#include <Potentials/potential.h>
-#include <InitialConditions/initialcondition.h>
-#include <particle.h>
+#include "system.h"
+#include "Integrators/integrator.h"
+#include "Potentials/potential.h"
+#include "InitialConditions/initialcondition.h"
+#include "particle.h"
 
+#include <iostream>
 using std::cout;
 using std::endl;
 
@@ -45,7 +45,7 @@ void System::setIntegrator(Integrator* integrator) {
 
 void System::setInitialCondition(InitialCondition* initialCondition) {
     m_initialCondition = initialCondition;
-    m_initialCondition->setupParticles(this);
+    m_initialCondition->setupParticles(*this);
 }
 
 void System::setDt(double dt) {

--- a/system.h
+++ b/system.h
@@ -1,6 +1,6 @@
 #pragma once
+#include "particle.h"
 #include <vector>
-#include <particle.h>
 #include <fstream>
 
 class System {


### PR DESCRIPTION
also using references instead of pointers where appropriate.

Include <> should only be used when referring to files not in project directory. In project directory we should use #include "" with relative paths. #include <> only works because Qt build system adds -I. in the compilation commands.
